### PR TITLE
Make full titlebar draggable

### DIFF
--- a/src/ui/components/GooglePlayMusic/GooglePlayMusic.js
+++ b/src/ui/components/GooglePlayMusic/GooglePlayMusic.js
@@ -3,7 +3,7 @@ import ReactElectronWebview from 'react-electron-web-view';
 
 import styles from './GooglePlayMusic.scss';
 
-const gpmJavaScript = 'gpm.js';
+const gpmJavaScript = '../dist/gpm.js';
 
 export default class GooglePlayMusic extends Component {
   static propTypes = {

--- a/src/ui/components/Titlebar/Titlebar.scss
+++ b/src/ui/components/Titlebar/Titlebar.scss
@@ -9,8 +9,10 @@
   margin: 0;
   position: absolute;
   z-index: 10;
-  margin-top: 20px;
-  margin-left: 20px;
+  padding-top: 20px;
+  padding-left: 20px;
+  box-sizing: border-box;
+  width: 80%;
 }
 
 .titlebar.webkit-draggable {


### PR DESCRIPTION
At the "Sign in" screen, the title bar was only draggable right around the control buttons. I've widened the title bar so that you can click and drag on a much larger area.

The title bar does not extend all the way across because then it would cover up the right hand controls during sign in and general use.

Currently, during general use, the window dragging is somewhat slow. I think this is the drag coming from `ReactElectronWebview`, but I can't be sure. Either way, this is more responsive.

I'm not sure about the change in GooglePlayMusic, but it stopped an error from happening, didn't cause any new errors, and looks like it's what was intended. The console was complaining that it couldn't open `gpm.js`, but it was happy about getting the built one from `/dist/`